### PR TITLE
Personal ringtones: Normalize numbers upon import

### DIFF
--- a/qml/pages/PersonalRingtones.qml
+++ b/qml/pages/PersonalRingtones.qml
@@ -42,6 +42,10 @@ Page {
                         } else {
                             number = arg2.number
                         }
+                        // Strip out spaces (and other separators) that might
+                        // be valid in contact list but not in personal
+                        // ringtones list.
+                        number = number.replace(/[^0-9+]/g, "")
                         var dialog = pageStack.replace("com.jolla.settings.system.SoundDialog", {
                             activeFilename: "",
                             activeSoundTitle: "no sound",


### PR DESCRIPTION
Contact list entries might contain spaces (or even other separators like dashes or slashes) to separate the number into groups. So far, such numbers could be assigned a personal ringtone but it was never actually triggered since the caller number does not contain the separator.
This PR strips out any invalid characters from the number upon import. This allows for separators in the contact list without them ending up in the personal ringtones list looked up upon calls.

fixes #3

---
*edit*: Just in case this ever comes up, you can keep this under WTFPL or relicense as you like. IMHO such a tiny change is not copyrightable but since IANAL, just in case I hereby explicitly transfer any copyright I may hold to the changes in this PR to @CODeRUS. :wink: